### PR TITLE
fix: update builder-aws image to fix circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
   dist_build_executor:
     working_directory: *workspace_root
     docker:
-      - image: 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:master # Contains helper scripts for Voltti Docker registry
+      - image: 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-809ad64eaee48225fba439142026079a49d0f1d5 # Contains helper scripts for Voltti Docker registry
 
 
 commands:


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
Set builder-aws image to specific version to fix image not found in CircleCI. Same thing has been done in infra repository. 

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] All Terraform changes adhere to the [infra conventions](https://voltti.atlassian.net/wiki/spaces/VOLTTI/pages/502136959/Infra-k+yt+nn+t)
- [x] The code is consistent with the existing code base
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All Terraform changes adhere to the [infra conventions](https://voltti.atlassian.net/wiki/spaces/VOLTTI/pages/502136959/Infra-k+yt+nn+t)
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master and force pushed if necessary before merging
```
